### PR TITLE
Add -remaining flag to estimate remaining time needed to finish the import

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,7 +129,7 @@ While traversing this xml file following nodes will be visited:
 
     $ php aoe_import.php
     Available actions:
-        -action importXml -importKey <importKey> -files <files> -profilerPath <fileName> -threadPoolSize <int> -threadBatchSize <int>
+        -action importXml -importKey <importKey> -files <files> -profilerPath <fileName> -threadPoolSize <int> -threadBatchSize <int> -remaining <bool>
         -action showConfiguration
 
 ### Parameters:
@@ -140,6 +140,7 @@ While traversing this xml file following nodes will be visited:
 * profilerPath: path to a log file with some basic profiling information
 * threadPoolSize: number of parallel threads
 * threadBatchSize: number of nodes (not processors!) proceesed in one fork
+* remaining: show estimation of remaining time needed to finish importer
 
 Running the example product importer:
 

--- a/shell/aoe_import.php
+++ b/shell/aoe_import.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'abstract.php';
+require_once 'shell/abstract.php';
 
 /**
  * Class Aoe_Import_Shell_Import
@@ -89,6 +89,11 @@ class Aoe_Import_Shell_Import extends Mage_Shell_Abstract
             Mage::throwException('No import key given.');
         }
         $importer->setImportKey($importKey);
+        
+        $showRemainingTime = $this->getArg('remaining');
+        if (!empty($showRemainingTime)) {
+            $importer->setShowRemainingTime($showRemainingTime);
+        }
 
         $files = $this->getInputFiles($this->getArg('files'));
         if (count($files) == 0) {

--- a/shell/aoe_import.php
+++ b/shell/aoe_import.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'shell/abstract.php';
+require_once 'abstract.php';
 
 /**
  * Class Aoe_Import_Shell_Import


### PR DESCRIPTION
I've added a remaining flag to indicate how much time is needed to finish the import. It loads the whole XML into a SimpleXMLElement in the beginning and counts the objects according to the path in the <aoe_import> setting in the module's configuration. This obviously increases the initial start up time (and might not even be able to load the whole file if it exceeds some limit), that is why I made it a separate flag.

Log line before;
==> (1) - [--- Processed //ProductExport[1]/Products[1]/Product[1] using processor 'Elgentos_Vendit_Model_ImportProducts' ---]

Log line after;
==> (1 / 2998 - estimated time left; 04:21:07) - [--- Processed //ProductExport[1]/Products[1]/Product[1] using processor 'Elgentos_Vendit_Model_ImportProducts' ---]
